### PR TITLE
Test `get_elements()` more thoroughly

### DIFF
--- a/cylc/uiserver/schema.py
+++ b/cylc/uiserver/schema.py
@@ -291,8 +291,6 @@ async def get_elements(root, info, **kwargs):
 
     _, field_ids = process_resolver_info(root, info, kwargs)
 
-    if hasattr(kwargs, 'id'):
-        kwargs['ids'] = [kwargs.get('id')]
     if field_ids:
         if isinstance(field_ids, str):
             field_ids = [field_ids]


### PR DESCRIPTION
Using Pytest parameterization to test the output of `get_elements()` for a range of inputs